### PR TITLE
イベントページのカラム幅を広く調整

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -327,3 +327,8 @@ html:not(.topGroupsDisplay) .fbChatSidebar ._1vze {
 #content_container > #rightCol {
     margin-left: 12px !important;
 }
+
+#content_container ._14i5 {
+  right: inherit;
+  width: 100% !important;
+}


### PR DESCRIPTION
## やりたいこと
- イベントページでのカラム幅小さいため読みにくいので幅を広げたい

 
![image](https://cloud.githubusercontent.com/assets/233012/26766136/3d9e6228-49c6-11e7-8b8d-3776579b4971.png)

![image](https://cloud.githubusercontent.com/assets/233012/26766141/5e305ab4-49c6-11e7-93a7-4cc10ccdc53c.png)


## やったこと
- 対象のカラムCSSを調整

![image](https://cloud.githubusercontent.com/assets/233012/26766147/7da2f906-49c6-11e7-9c6c-d17f853fe696.png)


## その他
一応イベント系のページは一通りみてみて以下が懸念事項です
- 以下の赤線内のボックスはイベントハンドラで調整しているようで最初裏に隠れてしまう
  
![image](https://cloud.githubusercontent.com/assets/233012/26766157/b75c67a4-49c6-11e7-8444-388a76d23954.png)

- タイトル画像のサイズ調整は難しそう (できていない)
![image](https://cloud.githubusercontent.com/assets/233012/26766163/d2edbbb2-49c6-11e7-8e27-c40db5cbe103.png)
